### PR TITLE
[Feature] Limit incoming events to the last 3 days

### DIFF
--- a/citygram/animal_care.rb
+++ b/citygram/animal_care.rb
@@ -3,6 +3,15 @@ require_relative './feature'
 
 module Citygram
   class AnimalCare
+
+    ALLOWED_HIERARCHIES = [
+      'Animal care : Stray',
+      'Animal care : Stray : Injured',
+      'Animal care : Stray : Loose',
+      'Animal care : Stray : Sick',
+      'Animal care : Stray : Welfare'
+    ].freeze
+
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Animal care', offset)
       response = JSON.parse(HTTParty.get(url).body)

--- a/citygram/animal_care.rb
+++ b/citygram/animal_care.rb
@@ -1,37 +1,14 @@
 require_relative './url'
+require_relative './feature'
 
 module Citygram
   class AnimalCare
-    def self.build_features(records)
-      one_week_ago = (Time.now.to_i - (7*24*60*60)) * 1000
-
-      records.map do |record|
-        lat = record['attributes']['Latitude'].to_f
-        lng = record['attributes']['Longitude'].to_f
-        created_at = record['attributes']['DateCreated'].to_i
-
-        next if lat == 0.0 || lng == 0.0
-        next if created_at < one_week_ago
-
-        title = record['attributes']['CategoryHierarchy']
-        {
-          'id'          => record['attributes']['GlobalID'],
-          'type'        => 'Feature',
-          'properties'  => record.merge('title' => title),
-          'geometry'    => {
-            'type'        => 'Point',
-            'coordinates' =>  [lng, lat]
-          }
-        }
-      end
-    end
-
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Animal care', offset)
       response = JSON.parse(HTTParty.get(url).body)
       records = response['features']
 
-      features = build_features(records)
+      features = Citygram::Feature.build(records)
 
       next_page_url =  Citygram::Url.build('Animal care', offset + 1000) if response['exceededTransferLimit']
 

--- a/citygram/animal_care.rb
+++ b/citygram/animal_care.rb
@@ -17,7 +17,7 @@ module Citygram
       response = JSON.parse(HTTParty.get(url).body)
       records = response['features']
 
-      features = Citygram::Feature.build(records)
+      features = Citygram::Feature.build(records, ALLOWED_HIERARCHIES)
 
       next_page_url =  Citygram::Url.build('Animal care', offset + 1000) if response['exceededTransferLimit']
 

--- a/citygram/animal_care.rb
+++ b/citygram/animal_care.rb
@@ -3,10 +3,15 @@ require_relative './url'
 module Citygram
   class AnimalCare
     def self.build_features(records)
+      one_week_ago = (Time.now.to_i - (7*24*60*60)) * 1000
+
       records.map do |record|
         lat = record['attributes']['Latitude'].to_f
         lng = record['attributes']['Longitude'].to_f
+        created_at = record['attributes']['DateCreated'].to_i
+
         next if lat == 0.0 || lng == 0.0
+        next if created_at < one_week_ago
 
         title = record['attributes']['CategoryHierarchy']
         {
@@ -29,6 +34,7 @@ module Citygram
       features = build_features(records)
 
       next_page_url =  Citygram::Url.build('Animal care', offset + 1000) if response['exceededTransferLimit']
+
       [{'features' => features.compact }.to_json, next_page_url]
     end
   end

--- a/citygram/code_enforcement.rb
+++ b/citygram/code_enforcement.rb
@@ -1,4 +1,5 @@
 require_relative './url'
+require_relative './feature'
 
 module Citygram
   class CodeEnforcement

--- a/citygram/code_enforcement.rb
+++ b/citygram/code_enforcement.rb
@@ -1,7 +1,7 @@
 require_relative './url'
 
 module Citygram
-    class CodeEnforcement
+  class CodeEnforcement
 
     ALLOWED_HIERARCHIES = [
       'Code Enforcement : Environmental : Complaint',
@@ -11,34 +11,12 @@ module Citygram
       'Code Enforcement : Work Without Permit'
     ].freeze
 
-    def self.build_features(records)
-      records.map do |record|
-        lat = record['attributes']['Latitude'].to_f
-        lng = record['attributes']['Longitude'].to_f
-        next if lat == 0.0 || lng == 0.0
-
-        category_hierarchy = record['attributes']['CategoryHierarchy']
-        next unless ALLOWED_HIERARCHIES.include?(category_hierarchy)
-
-        title = record['attributes']['CategoryHierarchy']
-        {
-          'id'          => record['attributes']['GlobalID'],
-          'type'        => 'Feature',
-          'properties'  => record.merge('title' => title),
-          'geometry'    => {
-            'type'        => 'Point',
-            'coordinates' =>  [lng, lat]
-          }
-        }
-      end
-    end
-
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Code Enforcement', offset)
       response = JSON.parse(HTTParty.get(url).body)
       records = response['features']
 
-      features = build_features(records)
+      features = Citygram::Feature.build(records, ALLOWED_HIERARCHIES)
 
       next_page_url =  Citygram::Url.build('Code Enforcement', offset + 1000) if response['exceededTransferLimit']
       [{'features' => features.compact }.to_json, next_page_url]

--- a/citygram/feature.rb
+++ b/citygram/feature.rb
@@ -1,0 +1,32 @@
+module Citygram
+  class Feature
+    THREE_DAYS_AGO = (Time.now.to_i - (3*24*60*60)) * 1000
+
+    def self.build(records, filter_list=[])
+      records.map do |record|
+        lat = record['attributes']['Latitude'].to_f
+        lng = record['attributes']['Longitude'].to_f
+        created_at = record['attributes']['DateCreated'].to_i
+
+        next if lat == 0.0 || lng == 0.0
+        next if created_at < THREE_DAYS_AGO
+
+        unless filter_list.empty?
+          category_hierarchy = record['attributes']['CategoryHierarchy']
+          next unless filter_list.include?(category_hierarchy)
+        end
+
+        title = record['attributes']['CategoryHierarchy']
+        {
+          'id'          => record['attributes']['GlobalID'],
+          'type'        => 'Feature',
+          'properties'  => record.merge('title' => title),
+          'geometry'    => {
+            'type'        => 'Point',
+            'coordinates' =>  [lng, lat]
+          }
+        }
+      end
+    end
+  end
+end

--- a/citygram/homeless.rb
+++ b/citygram/homeless.rb
@@ -1,4 +1,5 @@
 require_relative './url'
+require_relative './feature'
 
 module Citygram
   class Homeless

--- a/citygram/homeless.rb
+++ b/citygram/homeless.rb
@@ -2,40 +2,16 @@ require_relative './url'
 
 module Citygram
   class Homeless
-      ALLOWED_HIERARCHIES = [
+    ALLOWED_HIERARCHIES = [
       'Other : Homeless Camp'
-      ].freeze
-      
-    def self.build_features(records)
-      records.map do |record|
-        lat = record['attributes']['Latitude'].to_f
-        lng = record['attributes']['Longitude'].to_f
-        next if lat == 0.0 || lng == 0.0
-
-        
-
-        category_hierarchy = record['attributes']['CategoryHierarchy']
-        next unless ALLOWED_HIERARCHIES.include?(category_hierarchy)
-
-        title = record['attributes']['CategoryHierarchy']
-        {
-          'id'          => record['attributes']['GlobalID'],
-          'type'        => 'Feature',
-          'properties'  => record.merge('title' => title),
-          'geometry'    => {
-            'type'        => 'Point',
-            'coordinates' =>  [lng, lat]
-          }
-        }
-      end
-    end
+    ].freeze
 
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Other', offset)
       response = JSON.parse(HTTParty.get(url).body)
       records = response['features']
 
-      features = build_features(records)
+      features = Citygram::Feature.build(records, ALLOWED_HIERARCHIES)
 
       next_page_url =  Citygram::Url.build('Animal care', offset + 1000) if response['exceededTransferLimit']
       [{'features' => features.compact }.to_json, next_page_url]

--- a/citygram/sewer.rb
+++ b/citygram/sewer.rb
@@ -1,4 +1,5 @@
 require_relative './url'
+require_relative './feature'
 
 module Citygram
   class Sewer

--- a/citygram/sewer.rb
+++ b/citygram/sewer.rb
@@ -9,34 +9,12 @@ module Citygram
       'Sewer : Hazmat'
     ].freeze
 
-    def self.build_features(records)
-      records.map do |record|
-        lat = record['attributes']['Latitude'].to_f
-        lng = record['attributes']['Longitude'].to_f
-        next if lat == 0.0 || lng == 0.0
-
-        category_hierarchy = record['attributes']['CategoryHierarchy']
-        next unless ALLOWED_HIERARCHIES.include?(category_hierarchy)
-
-        title = record['attributes']['CategoryHierarchy']
-        {
-          'id'          => record['attributes']['GlobalID'],
-          'type'        => 'Feature',
-          'properties'  => record.merge('title' => title),
-          'geometry'    => {
-            'type'        => 'Point',
-            'coordinates' =>  [lng, lat]
-          }
-        }
-      end
-    end
-
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Sewer', offset)
       response = JSON.parse(HTTParty.get(url).body)
       records = response['features']
 
-      features = build_features(records)
+      features = Citygram::Feature.build(records, ALLOWED_HIERARCHIES)
 
       next_page_url =  Citygram::Url.build('Sewer', offset + 1000) if response['exceededTransferLimit']
       [{'features' => features.compact }.to_json, next_page_url]

--- a/citygram/urban_forestry.rb
+++ b/citygram/urban_forestry.rb
@@ -1,4 +1,5 @@
 require_relative './url'
+require_relative './feature'
 
 module Citygram
   class UrbanForestry

--- a/citygram/urban_forestry.rb
+++ b/citygram/urban_forestry.rb
@@ -6,35 +6,13 @@ module Citygram
 	ALLOWED_HIERARCHIES = [
   	'Urban Forestry : Inspection'
   ].freeze
-      
-	def self.build_features(records)
-		records.map do |record|
-      lat = record['attributes']['Latitude'].to_f
-      lng = record['attributes']['Longitude'].to_f
-			next if lat == 0.0 || lng == 0.0
-
-      category_hierarchy = record['attributes']['CategoryHierarchy']
-      next unless ALLOWED_HIERARCHIES.include?(category_hierarchy)
-
-      title = record['attributes']['CategoryHierarchy']
-      {
-        'id'          => record['attributes']['GlobalID'],
-        'type'        => 'Feature',
-        'properties'  => record.merge('title' => title),
-        'geometry'    => {
-        	'type'        => 'Point',
-        	'coordinates' =>  [lng, lat]
-          }
-        }
-      end
-    end
 
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Urban Forestry', 0)
       response = JSON.parse(HTTParty.get(url).body)
       records = response['features']
 
-      features = build_features(records)
+      features = Citygram::Feature.build(records, ALLOWED_HIERARCHIES)
 
       next_page_url =  Citygram::Url.build('Urban Forestry', offset + 1000) if response['exceededTransferLimit']
       [{'features' => features.compact }.to_json, next_page_url]

--- a/citygram/urban_forestry.rb
+++ b/citygram/urban_forestry.rb
@@ -3,10 +3,10 @@ require_relative './feature'
 
 module Citygram
   class UrbanForestry
-		
-	ALLOWED_HIERARCHIES = [
-  	'Urban Forestry : Inspection'
-  ].freeze
+
+    ALLOWED_HIERARCHIES = [
+      'Urban Forestry : Inspection'
+    ].freeze
 
     def self.retrieve_records(offset = 0)
       url = Citygram::Url.build('Urban Forestry', 0)


### PR DESCRIPTION
This PR adds the features of:

- limiting `features` built to the last 3 days;
- filtering of `features` for the `animal_care` endpoint.

The limiting of `features` to the last three days is currently being [done programmatically](https://github.com/code4sac/citygram-sacramento-api/blob/7f68847031d456162f9120b699cdf0988f3dc80d/citygram/feature.rb#L12) rather than in the [API query](https://github.com/code4sac/citygram-sacramento-api/blob/7f68847031d456162f9120b699cdf0988f3dc80d/citygram/url.rb#L8-L12). I was having difficulty [building the query per the docs](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service/02r3000000w5000000/) so this was the fastest way to unblock the issue. 

CC: @l84tahoe for any guidance on the above. 